### PR TITLE
commit float on windows created as floating windows

### DIFF
--- a/src/engine/window.ts
+++ b/src/engine/window.ts
@@ -149,7 +149,7 @@ class Window {
         this.timestamp = 0;
 
         this.internalState = WindowState.Unmanaged;
-        this.shouldCommitFloat = false;
+        this.shouldCommitFloat = this.shouldFloat;
         this.weightMap = {};
     }
 


### PR DESCRIPTION
This PR fixes #103 for me. I didn't dig super deep into the code base, but it works and the change makes sense to me:

**Symptom**

Windows automatically set as floating windows don't get raised.

**How to Reproduce**

1. Set for example `systemsettings` window class as floating window in the kronhkite rules 
1. Open any tiled window
2. Open the window and make sure it's floating
3. Click the tiled window behind the floating window

**Expected behavior**

The floating window should be kept above the tiled window, but instead the tiled window is raised above the floating window.

**Environment**
 - Distro: Arch
 - KWin version: 5.19.4-1
 - Krohnkite version: 5c89147
 - List of KWin scripts in use: none

**Notes**

If I "unfloat" the window and set it to floating by pressing `Meta+F` twice, the window _does_ actually float above all others and no tiled window gets raised above it. It only applies to windows that automatically get floating status by rules. It doesn't matter if that window is set on the ignore rules or floating rules
