### PR TITLE
Border size documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ convinient if title bars are removed.
         kwriteconfig5 --file ~/.config/kdeglobals --group WM --key inactiveFrame  239,240,241
 4. You must **restart** your session to see changes. (i.e. re-login, reboot)
 
-(Note: the RGB values presented here are for the default Breeze theme)
+Note: the RGB values presented here are for the default Breeze theme
+
+Note: You might also need to set the border size larger than the theme's default:
+`System Settings` > `Application Style` > `Window Decorations`: Untick `Use theme's default window border size` and adjust the size (right from the checkbox).
 
 
 Useful Development Resources


### PR DESCRIPTION
I had issues getting the focus to display when moving between windows, even after setting the values according to the README.md, due to the border size in my theme being 0 (or unnoticeable). I noticed that other people had similar issues online, also using Krohnkite. I figured I'd share my solution here.