### PR TITLE
Don't make natively maximised windows *always on top*

### DIFF
--- a/src/driver/kwin/kwinwindow.ts
+++ b/src/driver/kwin/kwinwindow.ts
@@ -101,9 +101,6 @@ class KWinWindow implements IDriverWindow {
     }
 
     public commit(geometry?: Rect, noBorder?: boolean, keepAbove?: boolean) {
-        if (this.maximized)
-            keepAbove = true;
-
         debugObj(() => ["KWinWindow#commit", { geometry, noBorder, keepAbove }]);
 
         if (this.client.move || this.client.resize)

--- a/src/engine/window.ts
+++ b/src/engine/window.ts
@@ -158,7 +158,7 @@ class Window {
         debugObj(() => ["Window#commit", {state: WindowState[state]}]);
         switch (state) {
             case WindowState.NativeMaximized:
-                this.window.commit(undefined, undefined, undefined);
+                this.window.commit(undefined, undefined, false);
                 break;
 
             case WindowState.NativeFullscreen:


### PR DESCRIPTION
All I did was implement the changes you recommended [here](https://github.com/esjeon/krohnkite/issues/64#issuecomment-645662679) and [here](https://github.com/esjeon/krohnkite/issues/64#issuecomment-647190211). I'm not sure why the default behaviour is to make natively maximised windows *always on top*. I'm not familiar with your codebase, so please discard this pull request if you think it might cause problems.