### PR TITLE
Minimum Size for all Windows to prevent unwanted overlap

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ Note: the RGB values presented here are for the default Breeze theme
 Note: You might also need to set the border size larger than the theme's default:
 `System Settings` > `Application Style` > `Window Decorations`: Untick `Use theme's default window border size` and adjust the size (right from the checkbox).
 
+### Setting Minimum Geometry Size ###
+
+Some applications like discord and KDE settings dont tile nicely as they have a minimum size requirement.
+This causes the applications to overlap with other applications. To mitigate this we can set minimum size for all windows to be 0.
+
+1. `System Setting` > `Window Management` > `Window Rules`
+2. Click on `+ Add New...`
+3. Set `Window class` to be `Unimportant`
+4. Set `Window types` to `Normal Window`
+5. Click `+ Add Properties...`
+6. Add the `Minimum Size` Property
+7. Set the fields to `Force` and `0` x `0`
+8. Apply
 
 Useful Development Resources
 ----------------------------


### PR DESCRIPTION
I was facing this problem as some of my applications like discord, and KDE settings itself would not tile properly (in 1080p screen) due to the windows having a set 'minimum size'. This can be overwritten using the `Window Rules` settings in KDE settings to apply to all normal windows. I have added how to do that in the README file. If there's a better solution or I am doing something wrong let me know and feel free to discard the PR.