### PR TITLE
monoclelayout.ts: with 'minimize unfocused...' enabled, only minimize…

### DIFF
--- a/src/layouts/monoclelayout.ts
+++ b/src/layouts/monoclelayout.ts
@@ -40,7 +40,9 @@ class MonocleLayout implements ILayout {
                 const current = ctx.currentWindow;
                 if (current && current.tiled) {
                     tiles.forEach((window) => {
-                        if (window !== current)
+                        if (window !== current 
+                            && (window.window as KWinWindow).client.screen
+                            === (current.window as KWinWindow).client.screen)
                             (window.window as KWinWindow).client.minimized = true;
                     });
                 }


### PR DESCRIPTION
closes #158

Figured this would be a simple fix and it was :)

Just added a check in `MonocleLayout.apply()` to only minimize unfocused windows if they are on the same screen as the window that just got focus.