### PR TITLE
Use npm scripts and wrap makefile around it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
-/pkg/
+/build/
 /node_modules/
 
 /TODO.md
 /krohnkite.js
 /package-lock.json
-/package.json
 
 /*.qml
 *.kwinscript

--- a/Makefile
+++ b/Makefile
@@ -1,76 +1,27 @@
-PROJECT_NAME = krohnkite
-PROJECT_VER  = 0.8
-PROJECT_REV  = $(shell git rev-parse HEAD | cut -b-7)
-
-KWINPKG_FILE = $(PROJECT_NAME)-$(PROJECT_VER).kwinscript
-KWINPKG_DIR = pkg
-
-KWIN_META   = $(KWINPKG_DIR)/metadata.desktop
-KWIN_QML    = $(KWINPKG_DIR)/contents/ui/main.qml
-
-NODE_SCRIPT = krohnkite.js
-NODE_META   = package.json
-NODE_FILES  = $(NODE_SCRIPT) $(NODE_META) package-lock.json
-
-SRC = $(shell find src -name "*.ts")
-
-all: $(KWINPKG_DIR)
+all: build
 
 clean:
-	@rm -rvf $(KWINPKG_DIR)
-	@rm -vf $(NODE_FILES)
+	npm run clean
 
-install: package
-	plasmapkg2 -t kwinscript -s $(PROJECT_NAME) \
-		&& plasmapkg2 -u $(KWINPKG_FILE) \
-		|| plasmapkg2 -i $(KWINPKG_FILE)
-		
-uninstall:
-	plasmapkg2 -t kwinscript -r $(PROJECT_NAME)
+build:
+	npm run build
 
-package: $(KWINPKG_FILE)
-
-test: $(NODE_SCRIPT) $(NODE_META)
-	npm test
-
-run: $(KWINPKG_DIR)
-	bin/load-script.sh "$(KWIN_QML)" "$(PROJECT_NAME)-test"
-	@find "$(KWINPKG_DIR)" '(' -name "*.qmlc" -o -name "*.jsc" ')' -delete
+run start:
+	npm start
 
 stop:
-	bin/load-script.sh "unload" "$(PROJECT_NAME)-test"
+	npm stop
 
-$(KWINPKG_FILE): $(KWINPKG_DIR)
-	@rm -f "$(KWINPKG_FILE)"
-	@7z a -tzip $(KWINPKG_FILE) ./$(KWINPKG_DIR)/*
+test:
+	npm test
 
-$(KWINPKG_DIR): $(KWIN_META)
-$(KWINPKG_DIR): $(KWIN_QML)
-$(KWINPKG_DIR): $(KWINPKG_DIR)/contents/ui/config.ui
-$(KWINPKG_DIR): $(KWINPKG_DIR)/contents/ui/popup.qml
-$(KWINPKG_DIR): $(KWINPKG_DIR)/contents/code/script.js
-$(KWINPKG_DIR): $(KWINPKG_DIR)/contents/config/main.xml
-	@touch $@
+package:
+	npm run package
 
-$(KWIN_META): res/metadata.desktop
-	@mkdir -vp `dirname $(KWIN_META)`
-	sed "s/\$$VER/$(PROJECT_VER)/" $< \
-		| sed "s/\$$REV/$(PROJECT_REV)/" \
-		> $(KWIN_META)
+install:
+	npm run install
 
-$(KWIN_QML): res/main.qml
-$(KWINPKG_DIR)/contents/ui/config.ui: res/config.ui
-$(KWINPKG_DIR)/contents/ui/popup.qml: res/popup.qml
-$(KWINPKG_DIR)/contents/code/script.js: $(NODE_SCRIPT)
-$(KWINPKG_DIR)/contents/config/main.xml: res/config.xml
-$(KWINPKG_DIR)/%:
-	@mkdir -vp `dirname $@`
-	@cp -v $< $@
+uninstall:
+	npm run uninstall
 
-$(NODE_SCRIPT): $(SRC)
-	tsc
-
-$(NODE_META): res/package.json
-	sed "s/\$$VER/$(PROJECT_VER).0/" $< > $@
-
-.PHONY: all clean install package test run stop
+.PHONY: all clean build run start stop test package pack install

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+set -e
+
+# Make necessary directories
+mkdir -p $npm_package_config_build_dir/contents/code
+mkdir -p $npm_package_config_build_dir/contents/config
+mkdir -p $npm_package_config_build_dir/contents/ui
+
+# Compile source into the single script used by KWin
+echo "Compiling typescript..."
+tsc --outFile $npm_package_config_build_dir/contents/code/script.js
+
+# Copy resources to the build directory with correct paths
+cp -v res/config.ui $npm_package_config_build_dir/contents/ui/config.ui
+cp -v res/popup.qml $npm_package_config_build_dir/contents/ui/popup.qml
+cp -v res/main.qml $npm_package_config_build_dir/contents/ui/main.qml
+cp -v res/config.xml $npm_package_config_build_dir/contents/config/main.xml
+
+# Copy and update metadata
+METADATA_FILE=$npm_package_config_build_dir/metadata.desktop
+PROJECT_REV=$(git rev-parse HEAD | cut -b-7)
+
+cp -v res/metadata.desktop $METADATA_FILE
+sed -i "s/\$VER/$npm_package_version/" $METADATA_FILE
+sed -i "s/\$REV/$PROJECT_REV/" $METADATA_FILE
+

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -e
+
+# Remove build directory and package-lock
+rm -vrf $npm_package_config_build_dir
+rm -vf $npm_package_config_node_script package-lock.json

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+# Display info and upgrade/install script
+KWINPKG_FILE="${npm_package_name}-${npm_package_version}.kwinscript"
+plasmapkg2 -t kwinscript -s $npm_package_name && plasmapkg2 -u "$KWINPKG_FILE" || plasmapkg2 -i "$KWINPKG_FILE"
+

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+
+KWINPKG_FILE="${npm_package_name}-${npm_package_version}.kwinscript"
+
+# Remove old archive
+rm -f "$KWINPKG_FILE"
+
+# Create new installable package
+7z a -tzip "$KWINPKG_FILE" ./$npm_package_config_build_dir/*

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -e
+
+# Load script to KWin
+bin/load-script.sh "$npm_package_config_build_dir/contents/ui/main.qml" \
+  "$npm_package_name-test"
+
+# Remove unnecessary files
+find "$npm_package_config_build_dir" \
+  '(' -name "*.qmlc" -o -name "*.jsc" ')' -delete

--- a/bin/stop.sh
+++ b/bin/stop.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -e
+
+# Unload script from KWin
+bin/load-script.sh "unload" "$npm_package_name-test"

--- a/bin/uninstall.sh
+++ b/bin/uninstall.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+
+plasmapkg2 -t kwinscript -r $npm_package_name

--- a/package.json
+++ b/package.json
@@ -1,16 +1,31 @@
 {
   "name": "krohnkite",
-  "version": "$VER",
+  "version": "0.8.0",
   "description": "A dynamic tiling extension for KWin",
   "main": "krohnkite.js",
   "directories": {
+    "build": "build",
     "test": "test"
+  },
+  "config": {
+    "node_script": "krohnkite.js",
+    "build_dir": "build"
   },
   "dependencies": {},
   "devDependencies": {
     "mocha": "^6.0.0"
   },
   "scripts": {
+    "clean": "bin/clean.sh",
+    "build": "bin/build.sh",
+    "prestart": "npm run build",
+    "start": "bin/start.sh",
+    "stop": "bin/stop.sh",
+    "prepackage": "npm run build",
+    "package": "bin/package.sh",
+    "preinstall": "npm run package",
+    "install": "bin/install.sh",
+    "uninstall": "bin/uninstall.sh",
     "test": "mocha 'test/*.spec.js'"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,17 @@
 {
-    "compileOnSave": true,
-    "compilerOptions": {
-        "target": "es5",
-        "outFile": "krohnkite.js",
-        "noEmitOnError": false,
-        "removeComments": true,
-        "lib": ["es5"],
-        "alwaysStrict": true,
-        "strict": true
-    }
+  "compileOnSave": true,
+  "compilerOptions": {
+    "target": "es5",
+    "noEmitOnError": false,
+    "removeComments": true,
+    "lib": [
+      "es5"
+    ],
+    "alwaysStrict": true,
+    "strict": true
+  },
+  "include": [
+    "src/**/*",
+    "test/**/*"
+  ]
 }


### PR DESCRIPTION
Advantages:
- Building description is more readable (top to bottom)
- Build step is extracted from package step
- Abstraction layers are not mixed within the tools ("Scripts describe
  how to build, Npm calls scripts, Make calls Npm" instead of "Make
  describes build, calls Npm")
- No duplication of package description in Makefile and package.json

## How to test

Run all make commands:
```
clean
build
run
start
stop
test
package
install
uninstall
```
